### PR TITLE
Use an env var as the default base_url if one exists

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,14 +69,10 @@ You can specify the base URL using a `configuration file`_:
   [pytest]
   base_url = http://www.example.com
 
-Using an environment variable
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Environment Variable
+^^^^^^^^^^^^^^^^^^^^
 
-You can specify the base URL with an environment variable:
-
-.. code-block:: bash
-
-   export PYTEST_BASE_URL="http://www.example.com"
+You can specify the base URL by setting the `PYTEST_BASE_URL` environment variable.
 
 Using a Fixture
 ^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,15 @@ You can specify the base URL using a `configuration file`_:
   [pytest]
   base_url = http://www.example.com
 
+Using an environment variable
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can specify the base URL with an environment variable:
+
+.. code-block:: bash
+
+   export PYTEST_BASE_URL="http://www.example.com"
+
 Using a Fixture
 ^^^^^^^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -69,10 +69,10 @@ You can specify the base URL using a `configuration file`_:
   [pytest]
   base_url = http://www.example.com
 
-Environment Variable
-^^^^^^^^^^^^^^^^^^^^
+Using an Environment Variable
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can specify the base URL by setting the `PYTEST_BASE_URL` environment variable.
+You can specify the base URL by setting the ``PYTEST_BASE_URL`` environment variable.
 
 Using a Fixture
 ^^^^^^^^^^^^^^^

--- a/pytest_base_url/plugin.py
+++ b/pytest_base_url/plugin.py
@@ -45,6 +45,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--base-url',
         metavar='url',
+        default=os.getenv('PYTEST_BASE_URL', None),
         help='base url for the application under test.')
     parser.addoption(
         '--verify-base-url',

--- a/tests/test_base_url.py
+++ b/tests/test_base_url.py
@@ -54,3 +54,15 @@ def test_skip_config(testdir):
     """)
     result = testdir.runpytest()
     assert result.ret == 0
+
+
+def test_env_var_set(testdir, monkeypatch):
+    testdir.makepyfile("""
+        def test_config(request, base_url):
+            assert request.config.getvalue('base_url')
+            assert base_url == 'yeehaw'
+    """)
+    monkeypatch.setenv('PYTEST_BASE_URL', 'yeehaw')
+    reprec = testdir.inline_run()
+    passed, skipped, failed = reprec.listoutcomes()
+    assert len(passed) == 1


### PR DESCRIPTION
A pr for issue #1. If an environment variable for `PYTEST_BASE_URL` is set, pytest-base-url will use it as the default url.

- Note, I'm not sure if defaulting to `None` is required. I chose a default of `None` for semantics and readability. The test suite passes for both variations; `default=os.getenv('PYTEST_BASE_URL', None)` and `default=os.getenv('PYTEST_BASE_URL')`