### PR TITLE
Add verify base URL timeouts

### DIFF
--- a/pytest_base_url/plugin.py
+++ b/pytest_base_url/plugin.py
@@ -6,7 +6,6 @@ import os
 
 import pytest
 import requests
-
 from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
 
@@ -29,17 +28,7 @@ def _verify_url(request, base_url):
         retries = Retry(backoff_factor=0.1,
                         status_forcelist=[500, 502, 503, 504])
         session.mount(base_url, HTTPAdapter(max_retries=retries))
-        try:
-            session.get(base_url)
-        except Exception:
-            raise pytest.UsageError(
-                    'Base URL failed verification!'
-                    '\nURL: {0}'
-                    '\nPotential HTTP error codes: {1} .'
-                    '\nTried {2} times'
-                    '\nResponse headers: {3}'.format(
-                        base_url, retries.status_forcelist,
-                        retries.total, session.headers))
+        session.get(base_url)
 
 
 def pytest_configure(config):

--- a/tests/test_verify_base_url.py
+++ b/tests/test_verify_base_url.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import time
-
 import pytest
 
 from requests.packages.urllib3.util.retry import Retry

--- a/tests/test_verify_base_url.py
+++ b/tests/test_verify_base_url.py
@@ -30,7 +30,8 @@ def test_enable_verify_via_cli(testdir, httpserver, monkeypatch):
     assert len(failed) == 1
     out = failed[0].longrepr.reprcrash.message
     assert 'Max retries exceeded with url:' in out
-    assert "Caused by ResponseError('too many 500 error responses',)" in out
+    assert 'Caused by ResponseError' in out
+    assert 'too many 500 error responses' in out
 
 
 def test_enable_verify_via_env(testdir, httpserver, monkeypatch):
@@ -44,7 +45,8 @@ def test_enable_verify_via_env(testdir, httpserver, monkeypatch):
     assert len(failed) == 1
     out = failed[0].longrepr.reprcrash.message
     assert 'Max retries exceeded with url:' in out
-    assert "Caused by ResponseError('too many 500 error responses',)" in out
+    assert 'Caused by ResponseError' in out
+    assert 'too many 500 error responses' in out
 
 
 def test_disable_verify_via_env(testdir, httpserver, monkeypatch):
@@ -62,4 +64,8 @@ def test_url_fails(testdir, httpserver, monkeypatch):
     reprec = testdir.inline_run('--base-url', 'http://foo',
                                 '--verify-base-url')
     passed, skipped, failed = reprec.listoutcomes()
+    out = failed[0].longrepr.reprcrash.message
     assert len(failed) == 1
+    assert 'Max retries exceeded with url:' in out
+    assert 'Caused by NewConnectionError' in out
+    assert 'Failed to establish a new connection' in out

--- a/tests/test_verify_base_url.py
+++ b/tests/test_verify_base_url.py
@@ -2,7 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import time
+
 import pytest
+
+from requests.packages.urllib3.util.retry import Retry
 
 
 @pytest.fixture(autouse=True)
@@ -20,6 +24,7 @@ def test_ignore_bad_url_by_default(testdir, httpserver):
 def test_enable_verify_via_cli(testdir, httpserver, monkeypatch):
     testdir.makepyfile('def test_pass(): pass')
     monkeypatch.setenv('VERIFY_BASE_URL', False)
+    monkeypatch.setattr(Retry, 'BACKOFF_MAX', 5)
     status_code = 500
     httpserver.serve_content(content='<h1>Error!</h1>', code=status_code)
     reprec = testdir.inline_run('--base-url', httpserver.url,
@@ -29,13 +34,15 @@ def test_enable_verify_via_cli(testdir, httpserver, monkeypatch):
     out = failed[0].longrepr.reprcrash.message
     assert 'UsageError: Base URL failed verification!' in out
     assert 'URL: {0}'.format(httpserver.url) in out
-    assert 'Response status code: {0}'.format(status_code) in out
+    assert 'Potential HTTP error codes: [500, 502, 503, 504].'
+    assert 'Tried 10 times' in out
     assert 'Response headers: ' in out
 
 
 def test_enable_verify_via_env(testdir, httpserver, monkeypatch):
     testdir.makepyfile('def test_pass(): pass')
     monkeypatch.setenv('VERIFY_BASE_URL', True)
+    monkeypatch.setattr(Retry, 'BACKOFF_MAX', 5)
     status_code = 500
     httpserver.serve_content(content='<h1>Error!</h1>', code=status_code)
     reprec = testdir.inline_run('--base-url', httpserver.url)
@@ -44,7 +51,8 @@ def test_enable_verify_via_env(testdir, httpserver, monkeypatch):
     out = failed[0].longrepr.reprcrash.message
     assert 'UsageError: Base URL failed verification!' in out
     assert 'URL: {0}'.format(httpserver.url) in out
-    assert 'Response status code: {0}'.format(status_code) in out
+    assert 'Potential HTTP error codes: [500, 502, 503, 504].'
+    assert 'Tried 10 times' in out
     assert 'Response headers: ' in out
 
 
@@ -54,3 +62,21 @@ def test_disable_verify_via_env(testdir, httpserver, monkeypatch):
     httpserver.serve_content(content='<h1>Error!</h1>', code=500)
     result = testdir.runpytest('--base-url', httpserver.url)
     assert result.ret == 0
+
+
+def test_verify_retries_url(testdir, httpserver, monkeypatch):
+    testdir.makepyfile('def test_pass(): pass')
+    monkeypatch.setenv('VERIFY_BASE_URL', False)
+    monkeypatch.setattr(Retry, 'BACKOFF_MAX', 5)
+    httpserver.serve_content(content='<h1>Error!</h1>', code=500)
+    reprec = testdir.inline_run('--base-url', httpserver.url,
+                                '--verify-base-url')
+    passed, skipped, failed = reprec.listoutcomes()
+    assert len(failed) == 1
+    out = failed[0].longrepr.reprcrash.message
+    assert 'UsageError: Base URL failed verification!' in out
+    httpserver.serve_content(content='<h1>Loaded!</h1>')
+    reprec = testdir.inline_run('--base-url', httpserver.url,
+                                '--verify-base-url')
+    passed, skipped, failed = reprec.listoutcomes()
+    assert len(passed) == 1


### PR DESCRIPTION
This is for issue #3 

r? @davehunt 

I ran into some interesting issues. When the base URL verification fails, there is no header or status code given from the page. I removed those from the print because I couldn't see how to get anything back from the variable after it threw an exception. 

Now I think some pages that don't exist would throw a 500, and such. However, this
 ```
try:
       response.status_code == requests.codes.ok
``` 
throws an ```UnboundLocalError```, because the URL was not found. But since the variable ```response``` is within a ```try, except``` block as well, I can't access that variable to get the status code when it fails.

Please let me know what you think. I don't think I am too far off.