### PR TITLE
Avoid importing requests for test runs that don't need it

### DIFF
--- a/pytest_base_url/plugin.py
+++ b/pytest_base_url/plugin.py
@@ -5,9 +5,6 @@
 import os
 
 import pytest
-import requests
-from requests.packages.urllib3.util.retry import Retry
-from requests.adapters import HTTPAdapter
 
 
 @pytest.fixture(scope="session")
@@ -24,6 +21,12 @@ def _verify_url(request, base_url):
     """Verifies the base URL"""
     verify = request.config.option.verify_base_url
     if base_url and verify:
+        # The import is done here instead of globally to avoid importing
+        # requests for test runs that don't need it
+        import requests
+        from requests.packages.urllib3.util.retry import Retry
+        from requests.adapters import HTTPAdapter
+
         session = requests.Session()
         retries = Retry(backoff_factor=0.1, status_forcelist=[500, 502, 503, 504])
         session.mount(base_url, HTTPAdapter(max_retries=retries))


### PR DESCRIPTION
When running some unit tests at work the import of requests causes 0.16s of time. This is for a case where no one uses anything from this plugin, it's just installed because it's a dependency of pytest-selenium. 

Moving the import makes it possible to avoid the import overhead in some cases (not mine though, because of pytest-selenium that also imports stuff from requests at the top level).